### PR TITLE
refactor 

### DIFF
--- a/testOrganizer.go
+++ b/testOrganizer.go
@@ -4,30 +4,16 @@ import (
 	"fmt"
 	"encoding/csv"
 	"encoding/json"
-	// "io"
+	"io"
 	"os"
 	"regexp"
 	"github.com/cli/go-gh/v2"
-	// "github.com/cli/go-gh/v2/pkg/api"
+	"github.com/cli/go-gh/v2/pkg/api"
+	"net/http"
 )
 
 func main() {
-	// setup all the types needed to unmarshal our json array from its.json
-	// define struct for match object inside of textMatch object
-	type Match struct {
-		Indices []int `json:"indices"`
-		Text     string `json:"text"`
-	}
-
-	// define a struct for textMatch object 
-	type TextMatch struct {
-			Fragment  string `json:"fragment"`
-			Matches		[]Match `json:"matches"`
-			Property  string `json:"property"`
-			Type 			string `json:"type"`
-	}
-
-	// defined a struct for Repository object
+	// define a struct for Repository object
 	type Repository struct {
 		Id            string `json:"id"`
 		IsFork        bool `json:"isFork"`
@@ -40,7 +26,6 @@ func main() {
 	type Article struct {
 		Path        string `json:"path"`
 		Repository  Repository `json:"repository"`
-		TextMatches []TextMatch `json:"textMatches"`
 		Url         string `json:"url"`
 	}
 
@@ -48,7 +33,6 @@ func main() {
 	// define a test struct  - each Spec will have an array of these
 	type Test struct {
 		Name string
-		// indices []int
 	}
 
 	// define a spec struct - each repo will contain an array of these
@@ -66,28 +50,15 @@ func main() {
 
 	// finally, define a map of Repo's for our organized data
 	organizedTests := make(map[string]Repo)
-	testCount := 0;
-
-	// not using its.json anymore - now this go program runs the search, and parses the results without reading from a file
-	// but I may have to keep this around for debugging cus I can't run the gh search while debugging
-	// jsonFile, err := os.Open("its.json");
-	// if err != nil {
-  //   fmt.Println(err)
-  // }
-	// fmt.Println("Successfully Opened its.json")
-	// defer the closing of our jsonFile so that we can parse it later on
-	// defer jsonFile.Close()
-	// byteValue, _ := io.ReadAll(jsonFile)
+	testCount := 0
+	fileContentRequestCount := 0
 
 	// create an array of our Article structs 
 	var articles []Article
 
-	// unmarshal our json file into the articles array - again - not using this anymore but may keep for debugging
-	// json.Unmarshal([]byte(byteValue), &articles)
-
 	// run the search command and store the result - wonder when the limit of 500 will become a problem
-	fmt.Println("Executing command: gh search code it org:BidPal --extension cy.js -L 500 --json repository,path,textMatches,url")
-	buff, _, err := gh.Exec("search", "code", "it", "org:BidPal", "--extension", "cy.js", "-L", "500", "--json", "repository,path,textMatches,url")
+	fmt.Println("Executing command: gh search code org:BidPal --extension cy.js -L 500 --json repository,path,url")
+	buff, _, err := gh.Exec("search", "code", "org:BidPal", "--extension", "cy.js", "-L", "500", "--json", "repository,path,url")
 
 	if (err != nil) {
 			fmt.Printf("Error running gh search command: %s", err)
@@ -98,12 +69,12 @@ func main() {
 		fmt.Printf("Error unmarshalling search results to struct array: %s", xerr)
 	}
 
-	fmt.Printf("Search found matches in %d specs. Processing...\n", len(articles))
+	fmt.Printf("Search found %d specs. Processing...\n", len(articles))
 
-	// we now have an array of objects (matches) to organize
-	// lets loop thru it and make an object that is more useful for us
-	for _, match := range articles {
-		repoName := match.Repository.NameWithOwner
+	// we now have an array of specs in articles
+	// lets loop thru it searching each for tests, and writing those to our csv
+	for _, spec := range articles {
+		repoName := spec.Repository.NameWithOwner
 
 		// create an array of Specs, later used as organizedTests[repoName].Specs
 		var repoSpecs []Spec;
@@ -119,39 +90,55 @@ func main() {
 
 		// create a Spec for the current match that will be appended to repoSpecs later
 		currSpec := Spec{
-			Path: match.Path,
-			Url: match.Url,
+			Path: spec.Path,
+			Url: spec.Url,
 		}
 
-		// loop through textMatches array in current match, appending to currSpec.Tests as we go
-		for _, textMatch := range match.TextMatches {
-			// create regexp object we'll use to filter out search results that aren't actually its
-			// this pattern matches on whitespace, followed by "it(" followed by either `, ", or ',
-			// then it captures everything after the single/double quote or backtick up to the next single/double quote or backtick
-			// which should give us the test name (\x60 is backtick)
-			re, err := regexp.Compile(`\s+it\(["'\x60]([^"'\x60]+)["'\x60]`) 
-			if err != nil {
-				fmt.Println(err)
-			}
-			legit := re.FindStringSubmatch(textMatch.Fragment)
-			if (len(legit) > 1) {
-				currSpec.Tests = append(currSpec.Tests, Test{
-					Name: legit[1],
-				})
-				// increment test count and log test added to spec
-				testCount++
-				// logging for debugging - could write to a log file instead
-				// fmt.Printf("Added test %s \nto spec %s \n", legit[1], currSpec.Path)
-			} // else {
-				// log when matches are not added as test to spec - could write to a log file instead
-				// fmt.Printf("Did not add match %s \nto spec %s \n", textMatch.Fragment, currSpec.Path)
-			// }
+		// fetch the content of the current spec
+		path := fmt.Sprintf("repos/%s/contents/%s", repoName, spec.Path)
+			opts := api.ClientOptions{
+			Headers:   map[string]string{"Accept": "application/vnd.github.v3.raw","X-GitHub-Api-Version": "2022-11-28"},
+		}
+		client, err := api.NewRESTClient(opts)
+		if err != nil {
+			fmt.Println(err)
+		}
+		fmt.Printf("Fetching content of %s from %s via gh api\n", spec.Path, repoName)
+		response, err := client.Request(http.MethodGet, path, nil)
+		fileContentRequestCount++
+		if err != nil {
+			fmt.Println(err)
+		}
+		defer response.Body.Close()
+
+    resBody, err := io.ReadAll(response.Body)
+		if err != nil {
+        fmt.Printf("Cannot parse GET content response: %v\n", err)
+        return
+    }
+		// store string value of response (full file content for spec)
+		fileContent := string(resBody)
+		// create regexp object we'll use to filter out search results that aren't actually its
+		// this pattern matches on whitespace, followed by "it(" followed by either `, ", or ',
+		// then it captures everything after the single/double quote or backtick up to the next single/double quote or backtick
+		// which should give us the test name (\x60 is backtick)
+		re, err := regexp.Compile(`\s+it\(["'\x60]([^"'\x60]+)["'\x60]`) 
+		if err != nil {
+			fmt.Println(err)
+		}
+		
+		matches := re.FindAllStringSubmatch(fileContent, -1)
+		for _, match := range matches {
+			currSpec.Tests = append(currSpec.Tests, Test{
+				Name: match[1],
+			})
+			// increment test count and log test added to spec
+			testCount++
+			// fmt.Printf("Added test %s \nto spec %s \n", match[1], currSpec.Path)
 		}
 		repoSpecs = append(repoSpecs, currSpec)
-
 		// log when spec is added
 		// fmt.Printf("Added spec %s \nto repo %s \n", currSpec.Path, repoName)
-
 
 		// add/update repo in organizedTests
 		organizedTests[repoName] = Repo{
@@ -163,8 +150,8 @@ func main() {
 		// fmt.Printf("Added/Updated repo %s\n", repoName)
 	}
 	// done processing - log totals
+	fmt.Printf("%d requests made to github api to fetch file contents\n", fileContentRequestCount);
 	fmt.Printf("%d tests were found in %d repos and written to ./organizedTests.csv\n", testCount, len(organizedTests));
-
 	// ok now how do I write that nice struct out to a csv file?
 	// start by creating the array of arrays of strings I'd like to write to the file
 	var result [][]string


### PR DESCRIPTION
to search for files, then fetch content of each file and serch for tests. Got feedback that some tests were missing, turned out the gh search command was only returning 2 matches per file, causing lots of tests to be missing. So now the initial search command is just to get the repo/spec path/url and then we fetch each spec and run our regex against it to get the tests. The rest of the processing remains pretty much the same.